### PR TITLE
Added a Character Group with almost the same characters as in the movie. 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,22 @@ impl EZEmoji for AlphaNumeric {
     }
 }
 
+
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Classic;
+impl EZEmoji for Classic {
+    fn as_vec_u32(&self) -> Vec<u32> {
+        let mut classic = Japanese.as_vec_u32();                                //   Half-width katakana
+        // classic.extend_from_slice(&vec![26091]);                             //   日 --> Needs Double width
+        classic.extend_from_slice(&Numbers.as_vec_u32());                       //   0-9
+        classic.extend_from_slice(&vec![34, 42, 43, 45, 46, 58, 60, 61, 62 ]);  //   :."=*+-<>
+        classic.extend_from_slice(&vec![166, 124 ]);                            //   ¦|
+        classic
+    }
+}
+
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AllEmojis;
 impl EZEmoji for AllEmojis {


### PR DESCRIPTION
Hi! I made a new `Character` Group that mimics closely the character set from the movie. It is a basic combination of Katakana, Numbers and symbols. 

The main change occurs in this repo, but there is a corresponding change in the 'rusty-rain' to make the change available to the end user.

I based my selection in [this](https://scifi.stackexchange.com/a/182823). 

I found most characters in that list. The list includes 1 Kanji character, which I found, but is the only char that would need a DoubleWidth.. so I left it out of the final group.

I chose the name "classic", but I thought about naming it "Movie" or even "Matrix".. I leave it to you to decide if you want to change it. 

Have a good one!
Tono