### PR TITLE
Add open source category

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,6 +237,20 @@ impl EZEmoji for AlphaNumeric {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenSource;
+impl EZEmoji for OpenSource {
+    fn as_vec_u32(&self) -> Vec<u32> {
+        let mut open_source = (62208..=62325).collect::<Vec<u32>>(); // All Font Logos
+        open_source.retain(|&x| x != 62210); // Remove Apple logo
+        open_source.extend_from_slice(&[59205, 59257]); // Devicons
+        open_source.extend_from_slice(&[58930, 58931, 59054]); // Nerd Fonts custom icons
+        open_source.extend_from_slice(&[58975]); // Seti-UI
+        open_source.extend_from_slice(&[983211, 983714, 984444]); // Material Design Icons
+        open_source
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AllEmojis;
 impl EZEmoji for AllEmojis {
     fn as_vec_u32(&self) -> Vec<u32> {
@@ -254,6 +268,7 @@ impl EZEmoji for AllEmojis {
         all.extend_from_slice(&NumberedCubes.as_vec_u32());
         all.extend_from_slice(&LargeLetter.as_vec_u32());
         all.extend_from_slice(&AlphaNumeric.as_vec_u32());
+        all.extend_from_slice(&OpenSource.as_vec_u32());
         all
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,21 @@ impl EZEmoji for OpenSource {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProgrammingLanguages;
+impl EZEmoji for ProgrammingLanguages {
+    fn as_vec_u32(&self) -> Vec<u32> {
+        let prog_langs = vec![
+            57918, 58888, 58909, 58910, 58912, 58916, 58919, 58920, 58923, 58924, 58925, 58927,
+            58928, 58930, 58932, 58949, 58956, 58960, 58975, 58995, 58999, 59002, 59006, 59018,
+            59031, 59040, 59049, 59057, 59058, 59061, 59190, 59191, 59192, 59196, 59196, 59198,
+            59209, 59211, 59214, 59217, 59242, 59253, 59255, 59303, 59304, 59313, 60175, 60362,
+            61118, 62227, 62283, 983835, 984965, 985207, 985610, 987674,
+        ]; // From all Nerd Fonts
+        prog_langs
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AllEmojis;
 impl EZEmoji for AllEmojis {
     fn as_vec_u32(&self) -> Vec<u32> {
@@ -269,6 +284,7 @@ impl EZEmoji for AllEmojis {
         all.extend_from_slice(&LargeLetter.as_vec_u32());
         all.extend_from_slice(&AlphaNumeric.as_vec_u32());
         all.extend_from_slice(&OpenSource.as_vec_u32());
+        all.extend_from_slice(&ProgrammingLanguages.as_vec_u32());
         all
     }
 }


### PR DESCRIPTION
With these 2 patches users will be able to run:
```shell
rusty-rain -c open-source
```

All icons are available via Nerd Fonts, most of the icons are from font-logos but there are a lot of open source icons on other glyph packs.

I'm still tracking some missing icons, so anyone knows tell me to add it.

Glyphs outside `font-logos`:     󰊢  󰕼      

![image](https://github.com/cowboy8625/ezemoji/assets/53124818/376a5577-f8de-4967-ab96-6260770b5405)

--- 

### Compile rusty-rain yourself

You need git and cargo installed.

- Get patched `ezemoji` locally
```shell
git clone https://github.com/hasecilu/ezemoji.git && cd ezemoji
git checkout feat/open_source
```
- Get `rusty-rain` locally
```shell
git clone https://github.com/cowboy8625/rusty-rain.git
```
- Copy next patch to a file, apply it and compile. **Note**: Check in `Cargo.toml` that path to `ezemoji` crate points to the location you cloned the repo
```shell
git apply foss.diff
cargo build
./target/debug/rusty-rain -c open-source
```
_foss.diff_
```diff
diff --git a/Cargo.toml b/Cargo.toml
index 9ebcf67..c44bc97 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ clap = { version = "3.1.18", features = ["cargo"] }
 crossterm = "0.23.2"
 rand = "0.8.5"
 itertools = "0.10.3"
-ezemoji = "0.2.0"
+# ezemoji = "0.2.0"
+ezemoji = { path = "/home/user/git/github/ezemoji" }
 
 [profile.release]
 debug = true
diff --git a/src/arguments.rs b/src/arguments.rs
index 2987648..77c6b0a 100644
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -80,6 +80,7 @@ OPTIONS:
     num            - Good ol fashion Numbers
     numbered-balls - These are like pool balls
     numbered-cubes - These are like the pool balls but just cubes
+    open-source    - FOSS logos
     plants         - Plants of sorts
     smile          - 😃
     shapes         - Squares and Circles of a few colors
@@ -140,6 +141,7 @@ OPTIONS:
         "num" => Numbers.into(),
         "numbered-balls" => NumberedBalls.into(),
         "numbered-cubes" => NumberedCubes.into(),
+        "open-source" => OpenSource.into(),
         "plants" => Plant.into(),
         "smile" => Smile.into(),
         "shapes" => Shape.into(),
diff --git a/src/characters.rs b/src/characters.rs
index 82e5def..4564d24 100644
--- a/src/characters.rs
+++ b/src/characters.rs
@@ -35,6 +35,7 @@ pub enum Characters {
     Num(Numbers),
     NumberedBalls(NumberedBalls),
     NumberedCubes(NumberedCubes),
+    OpenSource(OpenSource),
     Plants(Plant),
     Smile(Smile),
     Shapes(Shape),
@@ -61,6 +62,7 @@ impl Characters {
             Self::Num(_) => CharWidth::Single.width(),
             Self::NumberedBalls(_) => CharWidth::Double.width(),
             Self::NumberedCubes(_) => CharWidth::Double.width(),
+            Self::OpenSource(_) => CharWidth::Double.width(),
             Self::Plants(_) => CharWidth::Double.width(),
             Self::Smile(_) => CharWidth::Double.width(),
             Self::Shapes(_) => CharWidth::Double.width(),
@@ -87,6 +89,7 @@ impl Characters {
             Self::Num(c) => c.as_vec_u32(),
             Self::NumberedBalls(c) => c.as_vec_u32(),
             Self::NumberedCubes(c) => c.as_vec_u32(),
+            Self::OpenSource(c) => c.as_vec_u32(),
             Self::Plants(c) => c.as_vec_u32(),
             Self::Smile(c) => c.as_vec_u32(),
             Self::Shapes(c) => c.as_vec_u32(),
@@ -202,6 +205,12 @@ impl From<ezemoji::NumberedCubes> for Characters {
     }
 }
 
+impl From<ezemoji::OpenSource> for Characters {
+    fn from(e: ezemoji::OpenSource) -> Self {
+        Self::OpenSource(e)
+    }
+}
+
 impl From<ezemoji::Plant> for Characters {
     fn from(e: ezemoji::Plant) -> Self {
         Self::Plants(e)
```
